### PR TITLE
terminal: fix refresh flicker and diagonal text

### DIFF
--- a/kernel/kernel/kernel.c
+++ b/kernel/kernel/kernel.c
@@ -32,10 +32,10 @@ extern void _i386_enter_pmode();
 
 void kernel_early() {
   // Set up kernel terminal for early output
-  //kernel_terminal_init(14);
+  kernel_terminal_init(14);
 
   // Set up i386 tables and functions
-  vga_textmode_initialize();
+  //vga_textmode_initialize();
   gdt_install();
   printk_debug("GDT Installed!");
   _i386_enter_pmode();
@@ -72,7 +72,6 @@ void kernel_main() {
 
   // Test kernel terminal
   kernel_buffer_stdout_writestring("Hello, Terminal!", strlen("Hello, Terminal!"));
-
   for(;;);
 }
 

--- a/kernel/kernel/kernel_terminal.c
+++ b/kernel/kernel/kernel_terminal.c
@@ -37,18 +37,21 @@ void kernel_terminal_init(uint16_t refresh_rate) {
 void kernel_terminal_update_tick() {
   uint16_t i;
 
-  // Clear current console
-  vga_textmode_clear();
-
-  // Restore old text from our buffer
-  vga_textmode_writestring(terminal_buffer);
-
   // Get kernel STDOUT buffer
   char stdout_buffer[STDOUT_MAX_BUFFER];
   uint16_t stdout_buffer_length = kernel_buffer_stdout_get(stdout_buffer);
 
-  for(i=0; i<stdout_buffer_length; i++) {
-    vga_textmode_putentryat(stdout_buffer[i], color, cur_xpos++, cur_ypos++);
-    terminal_buffer[terminal_buffer_length++] = stdout_buffer[i];
+  if(stdout_buffer_length != 0) {
+    // refresh current console
+    vga_textmode_clear();
+
+    // Restore old text from our buffer
+    vga_textmode_writestring(terminal_buffer);
+
+    // Update buffer
+    for(i=0; i<stdout_buffer_length; i++) {
+      vga_textmode_putentryat(stdout_buffer[i], color, cur_xpos++, cur_ypos);
+      terminal_buffer[terminal_buffer_length++] = stdout_buffer[i];
+    }
   }
 }


### PR DESCRIPTION
Updated `kernel_terminal_update_tick` to only update the screen if there is a change in stdout, and fixed a rogue `ypos++`
